### PR TITLE
Make API base URL configurable via environment variable

### DIFF
--- a/src/AiRecruiterCodeBase/dointo.airecruiter.web/src/app/modules/jobs/JobsList.tsx
+++ b/src/AiRecruiterCodeBase/dointo.airecruiter.web/src/app/modules/jobs/JobsList.tsx
@@ -25,7 +25,7 @@ const JobPost: React.FC = () => {
 
 	useEffect(() => {
 		axios
-			.get("https://localhost:7072/api/JobPosts")
+			.get(`${import.meta.env.VITE_APP_API_BASE_URL}/JobPosts`)
 			.then((res) => setJobPosts(res.data.data))
 			.catch((err) => console.error("Failed to fetch job posts:", err));
 	}, []);


### PR DESCRIPTION
Updated the `axios.get` call in the `useEffect` hook to use a dynamic base URL from `import.meta.env.VITE_APP_API_BASE_URL` instead of a hardcoded URL. This enhances flexibility and maintainability by allowing environment-specific configurations.